### PR TITLE
day7 module

### DIFF
--- a/19100303/liyan2019/main.py
+++ b/19100303/liyan2019/main.py
@@ -1,0 +1,8 @@
+from mymodule import stats_word as sw 
+# 后面没有冒号
+# from stats_word.py import stats_text  【注意这种错误和前述正确的区别】
+text='''
+中文中国. I love China and China.'''
+sw.stats_text(text)
+#为什么不是：sw(text)
+print(sw)

--- a/19100303/liyan2019/mymodule/stats_word.py
+++ b/19100303/liyan2019/mymodule/stats_word.py
@@ -28,3 +28,18 @@ def stats_text_en(text):
     # 上述if……else，与“wordcount=split_text.count(i)” 有什么区别？                
     wordcount=sorted(wordcount.items(),key=lambda x:x[1],reverse=True)
     return wordcount
+
+
+# 添加stats_text()函数，以调用 stats_text_cn(text) 和stats_text_en(text)，输出合并词频统计结果。
+
+## ?? 如何调用两个函数 【原来就是两个函数相加这么简单。】
+# 但是英文单词词频函数中包括了中文的情况--只要中文字中间没有空格，会将相连的中文字认定为一个单词，如何处理？】
+def stats_text(text):  # 合并中英文词频统计
+        """combine the stats_text_cn and stats_text_en,count english words and chinese characters"""
+        a = stats_text_en(text)
+        b = stats_text_cn(text)
+        c = a+b
+        print(c) #与前述a、b、c对齐，如果不对齐，而与 def 对齐则会出错。
+
+text='''合并中英文词频中英文。 python useful and interesting, go and run python.'''
+print(stats_text(text))


### PR DESCRIPTION
英文单词词频函数中包括了中文的情况--只要中文字中间没有空格，会将相连的中文字认定为一个单词，如何处理？】
stats_text_en(text):
    """count english words in the text"""
 
    replace_text=text.replace(',',' ').replace('.','').replace('!','').replace('*',' ').replace('-','').replace('?','')
  
    split_text=replace_text.split()
    wordcount={}
    for i in split_text:
        if i not in wordcount:
          
            wordcount[i]=1
        else:
        
            wordcount[i]+=1
     
    wordcount=sorted(wordcount.items(),key=lambda x:x[1],reverse=True)
    return wordcount

ext='''合并中英文词频中英文。 python useful and interesting, go and run python.'''
输出结果为：
[('python', 2), ('and', 2), ('合并中英文词频中英文。', 1), ('useful', 1), ('interesting', 1), ('go', 1), ('run', 1), ('中', 2), ('英', 2), ('文', 2), ('合', 1), ('并', 1), ('词', 1), ('频', 1)]