### PR TITLE
【1901100231】自学训练营学习18群 Day 07

### DIFF
--- a/exercises/1901100231/d07/mymodule/main.py
+++ b/exercises/1901100231/d07/mymodule/main.py
@@ -1,0 +1,64 @@
+text = '''
+愚公移⼭
+太⾏，王屋⼆⼭的北⾯，住了⼀个九⼗岁的⽼翁，名叫愚公。⼆⼭占地广阔，挡住去路，使他
+和家⼈往来极为不便。
+⼀天，愚公召集家⼈说：「让我们各尽其⼒，铲平⼆⼭，开条道路，直通豫州，你们认为怎
+样？」
+⼤家都异⼝同声赞成，只有他的妻⼦表示怀疑，并说：「你连开凿⼀个⼩丘的⼒量都没有，怎
+可能铲平太⾏、王屋⼆⼭呢？况且，凿出的⼟⽯⼜丢到哪里去呢？」
+⼤家都热烈地说：「把⼟⽯丢进渤海里。」
+于是愚公就和儿孙，⼀起开挖⼟，把⼟⽯搬运到渤海去。
+愚公的邻居是个寡妇，有个儿⼦⼋岁也兴致勃勃地⾛来帮忙。
+寒来暑往，他们要⼀年才能往返渤海⼀次。
+住在⿈河河畔的智叟，看⾒他们这样⾟苦，取笑愚公说：「你不是很愚蠢吗？你已⼀把年纪
+了，就是⽤尽你的气⼒，也不能挖去⼭的⼀⻆呢？」
+愚公叹息道：「你有这样的成⾒，是不会明⽩的。你⽐那寡妇的⼩儿⼦还不如呢！就算我死
+了，还有我的儿⼦，我的孙⼦，我的曾孙⼦，他们⼀直传下去。⽽这⼆⼭是不会加⼤的，总有
+⼀天，我们会把它们铲平。」
+智叟听了，无话可说：
+⼆⼭的守护神被愚公的坚毅精神吓倒，便把此事奏知天帝。天帝佩服愚公的精神，就命两位⼤
+⼒神背⾛⼆⼭。
+How The Foolish Old Man Moved Mountains
+Yugong was a ninety-year-old man who lived at the north of two high
+mountains, Mount Taixing and Mount Wangwu.
+Stretching over a wide expanse of land, the mountains blocked
+yugong’s way making it inconvenient for him and his family to get
+around.
+One day yugong gathered his family together and said,”Let’s do our
+best to level these two mountains. We shall open a road that leads
+to Yuzhou. What do you think?”
+All but his wife agreed with him.
+“You don’t have the strength to cut even a small mound,” muttered
+his wife. “How on earth do you suppose you can level Mount Taixin
+and Mount Wanwu? Moreover, where will all the earth and rubble go?”
+“Dump them into the Sea of Bohai!” said everyone.
+So Yugong, his sons, and his grandsons started to break up rocks and
+remove the earth. They transported the earth and rubble to the Sea
+of Bohai.
+Now Yugong’s neighbour was a widow who had an only child eight years
+old. Evening the young boy offered his help eagerly.
+Summer went by and winter came. It took Yugong and his crew a full
+year to travel back and forth once.
+On the bank of the Yellow River dwelled an old man much respected
+for his wisdom. When he saw their back-breaking labour, he ridiculed
+Yugong saying,”Aren’t you foolish, my friend? You are very old now,
+and with whatever remains of your waning strength, you won’t be able
+to remove even a corner of the mountain.”
+Yugong uttered a sigh and said,”A biased person like you will never
+understand. You can’t even compare with the widow’s little boy!”
+“Even if I were dead, there will still be my children, my
+grandchildren, my great grandchildren, my great great grandchildren.
+They descendants will go on forever. But these mountains will not
+grow any taler. We shall level them one day!” he declared with
+confidence.
+The wise old man was totally silenced.
+When the guardian gods of the mountains saw how determined Yugong
+and his crew were, they were struck with fear and reported the
+incident to the Emperor of Heavens.
+Filled with admiration for Yugong, the Emperor of Heavens ordered
+two mighty gods to carry the mountains away.
+'''
+#coding=gbk
+import re
+import stats_word
+stats_word.stats_text(text)

--- a/exercises/1901100231/d07/mymodule/stats_word.py
+++ b/exercises/1901100231/d07/mymodule/stats_word.py
@@ -1,0 +1,34 @@
+import re#运用正则表达式来去除符号和非目标文字
+def stats_text_en(x) :#定义英文单词词频统计函数
+  x = x.lower()#统一大小写以便排序
+  x = re.sub(u"[^\u0061-\u007a’']"," ",x)#去除非英文和’'符号的其他文本，防止影响英文词频的统计
+  x = x . replace("\n"," ")#去除换行符
+  copy = x.split(' ')#将文本转换为列表
+  copy = [i for i in copy if i != ""]#去除空格，避免影响统计结果
+  a = {}#创建新字典
+  for i in copy :#对copy中单词进行词频统计，此前已有的key的value值加一，此前未有的key的value为1
+    if i in a:
+      a[i] = a[i]+1
+    else:
+      a[i] = 1
+  b = sorted(a.items(),key=lambda x:x[1],reverse=True)#对合并字典排序得到合并词频统计结果
+  return(b)#返回值用于合并统计结果
+def stats_text_cn(x) :#定义汉字字频统计函数
+   x = re.sub(u"[^\u4e00-\u9fa5]"," ",x)#去除英文和其他非中文的特殊符号
+   x = x . replace("\n"," ")#去除换行符
+   x = x . replace(""," ")#由于汉字输入字和字之间无间隔会导致所有汉字文本共同算作列表中的一个元素，所以人为添加空格将汉字分隔开以便于统计。其余的套用英文文本处理的程序
+   copy = x.split(' ')#将文本转换为列表
+   copy = [i for i in copy if i != ""]#去除之前人为添加的空格，避免影响统计结果
+   a = {}#创建新字典
+   for i in copy :#对copy中汉字进行字频统计，此前已有的key的value值加一，此前未有的key的value为1
+    if i in a:
+      a[i] = a[i]+1
+    else:
+      a[i] = 1
+   b = sorted(a.items(),key=lambda x:x[1],reverse=True)#对合并字典排序得到合并词频统计结果
+   return(b)#返回值用于合并统计结果
+def stats_text(x) :#定义混合词频统计函数
+  stats_text_en(x)
+  stats_text_cn(x)#引用两函数分别得到两个词频统计结果
+  a = stats_text_cn(x)+stats_text_en(x)#合并两词频统计结果
+  print(a)#输出合并词频统计结果


### PR DESCRIPTION
有一个问题，pdf文档中提供的汉字文本中的部分字无法被正则表达式识别为汉字。以“山”字为例，山字均为出现在词频统计的输出结果中。经调试发现在python中打出来的这些字和提供的文本中的字存在差别，但是在粘贴到text中和wps文档中时却看不出差别。或许可以更换一下任务提供的文本？具体原因暂无头绪。
@XINGRUFANG 